### PR TITLE
Update MessageAPI.js

### DIFF
--- a/src/utils/MessageAPI.js
+++ b/src/utils/MessageAPI.js
@@ -265,9 +265,7 @@ class MessageAPI {
 
         const method = 'readChat';
 
-        const postData = {
-            'idMessage': idMessage,
-        }
+        const postData = {}
 
         this.addChadIdParam(postData, chatId)
         this.addPhoneParam(postData, phoneNumber)


### PR DESCRIPTION
delete `'idMessage': idMessage` from `postData{}`. 
It is a temporary fix to get readChat() to work at all, until reading by idMessage will be fixed in the API itself.