### PR TITLE
fix readChat()

### DIFF
--- a/src/utils/MessageAPI.js
+++ b/src/utils/MessageAPI.js
@@ -267,6 +267,7 @@ class MessageAPI {
 
         const postData = {}
 
+        this.addMessageIdParam(postData, idMessage)
         this.addChadIdParam(postData, chatId)
         this.addPhoneParam(postData, phoneNumber)
 
@@ -384,6 +385,12 @@ class MessageAPI {
     addPhoneParam(postData, phoneNumber) {
         if (phoneNumber) {
             postData.chatId = `${phoneNumber}@c.us`
+        }
+    }
+
+    addMessageIdParam(postData, idMessage){
+        if (idMessage) {
+            postData.idMessage = idMessage
         }
     }
 }

--- a/src/utils/MessageAPI.js
+++ b/src/utils/MessageAPI.js
@@ -265,9 +265,7 @@ class MessageAPI {
 
         const method = 'readChat';
 
-        const postData = {
-            'idMessage': idMessage,
-        }
+        const postData = {}
 
         this.addChadIdParam(postData, chatId)
         this.addPhoneParam(postData, phoneNumber)


### PR DESCRIPTION
added `this.addMessageIdParam(postData, idMessage)` inside `readChat()` function, so it is now possible to not pass `idMessage `